### PR TITLE
Client streaming tests

### DIFF
--- a/betterproto/grpc/util/async_channel.py
+++ b/betterproto/grpc/util/async_channel.py
@@ -81,17 +81,10 @@ class AsyncChannel(AsyncIterable[T]):
     """
 
     def __init__(
-        self,
-        source: Union[Iterable[T], AsyncIterable[T]] = tuple(),
-        *,
-        buffer_limit: int = 0,
-        close: bool = False,
+        self, *, buffer_limit: int = 0, close: bool = False,
     ):
         self._queue: asyncio.Queue[Union[T, object]] = asyncio.Queue(buffer_limit)
         self._closed = False
-        self._sending_task = (
-            asyncio.ensure_future(self.send_from(source, close)) if source else None
-        )
         self._waiting_recievers: int = 0
         # Track whether flush has been invoked so it can only happen once
         self._flushed = False
@@ -100,13 +93,14 @@ class AsyncChannel(AsyncIterable[T]):
         return self
 
     async def __anext__(self) -> T:
-        if self.done:
+        if self.done():
             raise StopAsyncIteration
         self._waiting_recievers += 1
         try:
             result = await self._queue.get()
             if result is self.__flush:
                 raise StopAsyncIteration
+            return result
         finally:
             self._waiting_recievers -= 1
             self._queue.task_done()
@@ -131,7 +125,7 @@ class AsyncChannel(AsyncIterable[T]):
 
     async def send_from(
         self, source: Union[Iterable[T], AsyncIterable[T]], close: bool = False
-    ):
+    ) -> "AsyncChannel[T]":
         """
         Iterates the given [Async]Iterable and sends all the resulting items.
         If close is set to True then subsequent send calls will be rejected with a
@@ -151,9 +145,10 @@ class AsyncChannel(AsyncIterable[T]):
                 await self._queue.put(item)
         if close:
             # Complete the closing process
-            await self.close()
+            self.close()
+        return self
 
-    async def send(self, item: T):
+    async def send(self, item: T) -> "AsyncChannel[T]":
         """
         Send a single item over this channel.
         :param item: The item to send
@@ -161,6 +156,7 @@ class AsyncChannel(AsyncIterable[T]):
         if self._closed:
             raise ChannelClosed("Cannot send through a closed channel")
         await self._queue.put(item)
+        return self
 
     async def recieve(self) -> Optional[T]:
         """
@@ -168,7 +164,7 @@ class AsyncChannel(AsyncIterable[T]):
         or None if the channel is closed before another item is sent.
         :return: An item from the channel
         """
-        if self.done:
+        if self.done():
             raise ChannelDone("Cannot recieve from a closed channel")
         self._waiting_recievers += 1
         try:
@@ -184,8 +180,6 @@ class AsyncChannel(AsyncIterable[T]):
         """
         Close this channel to new items
         """
-        if self._sending_task is not None:
-            self._sending_task.cancel()
         self._closed = True
         asyncio.ensure_future(self._flush_queue())
 

--- a/betterproto/tests/grpc/test_stream_stream.py
+++ b/betterproto/tests/grpc/test_stream_stream.py
@@ -1,0 +1,124 @@
+import asyncio
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+import pytest
+
+import betterproto
+from betterproto.grpc.util.async_channel import AsyncChannel
+
+
+@dataclass
+class Message(betterproto.Message):
+    body: str = betterproto.string_field(1)
+
+
+async def to_list(generator: AsyncIterator):
+    lis = []
+    async for value in generator:
+        lis.append(value)
+    return lis
+
+
+@pytest.fixture
+def expected_responses():
+    return [Message("Hello world 1"), Message("Hello world 2"), Message("Done")]
+
+
+class ClientStub:
+    async def connect(self, requests):
+        await asyncio.sleep(0.1)
+        async for request in requests:
+            await asyncio.sleep(0.1)
+            yield request
+        await asyncio.sleep(0.1)
+        yield Message("Done")
+
+
+@pytest.fixture
+def client():
+    # channel = Channel(host='127.0.0.1', port=50051)
+    # return ClientStub(channel)
+    return ClientStub()
+
+
+@pytest.mark.asyncio
+async def test_from_list_close_automatically(client, expected_responses):
+    requests = AsyncChannel(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=True
+    )
+
+    responses = client.connect(requests)
+
+    assert await to_list(responses) == expected_responses
+
+
+@pytest.mark.asyncio
+async def test_from_list_close_manually_immediately(client, expected_responses):
+    requests = AsyncChannel(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=False
+    )
+
+    requests.close()
+
+    responses = client.connect(requests)
+
+    assert await to_list(responses) == expected_responses
+
+
+@pytest.mark.asyncio
+async def test_from_list_close_manually_after_connect(client, expected_responses):
+    requests = AsyncChannel(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=False
+    )
+
+    responses = client.connect(requests)
+
+    requests.close()
+
+    assert await to_list(responses) == expected_responses
+
+
+@pytest.mark.asyncio
+async def test_send_from_before_connect_and_close_automatically(
+    client, expected_responses
+):
+    requests = AsyncChannel()
+
+    await requests.send_from(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=True
+    )
+
+    responses = client.connect(requests)
+
+    assert await to_list(responses) == expected_responses
+
+
+@pytest.mark.asyncio
+async def test_send_from_after_connect_and_close_automatically(
+    client, expected_responses
+):
+    requests = AsyncChannel()
+
+    responses = client.connect(requests)
+
+    await requests.send_from(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=True
+    )
+
+    assert await to_list(responses) == expected_responses
+
+
+@pytest.mark.asyncio
+async def test_send_from_close_manually_immediately(client, expected_responses):
+    requests = AsyncChannel()
+
+    responses = client.connect(requests)
+
+    await requests.send_from(
+        [Message(body="Hello world 1"), Message(body="Hello world 2")], close=False
+    )
+
+    requests.close()
+
+    assert await to_list(responses) == expected_responses


### PR DESCRIPTION
I spent today getting intimate with the Client Stream/Stream connections.

This PR contains some changes to fix some basic use-cases.

However, I could not fix all scenarios that I thought were intended to be supported.

I've added a test file that I have run against a real gRPC server (it returns all messages verbatim, plus another 'Done' message at the end).

    betterproto/tests/grpc/test_stream_stream.py

In the end I found that its possible to run the same tests with a fake client that is simply an async generator, but I recommend testing this with an actual server to be sure we have tested this feature end-to-end before release.